### PR TITLE
remove sensitive permissions and update sdk

### DIFF
--- a/Assets/YumiMediationSDK/Editor/YumiMobileAdsDependencies.xml
+++ b/Assets/YumiMediationSDK/Editor/YumiMobileAdsDependencies.xml
@@ -1,19 +1,18 @@
 <dependencies>
   <androidPackages>
-    <androidPackage spec="com.yumimobi.ads:mediation:3.4.+" />
-    <androidPackage spec="com.yumimobi.ads.mediation:applovin:3.4.+" />
-    <androidPackage spec="com.yumimobi.ads.mediation:playableads:3.4.+" />
-    <androidPackage spec="com.yumimobi.ads.mediation:admob:3.4.+" />
-    <androidPackage spec="com.yumimobi.ads.mediation:chartboost:3.4.+" />
-    <androidPackage spec="com.yumimobi.ads.mediation:facebook:3.4.+" />
-    <androidPackage spec="com.yumimobi.ads.mediation:mraid:3.4.+" />
-    <androidPackage spec="com.yumimobi.ads.mediation:vungle:3.4.+" />
-    <androidPackage spec="com.yumimobi.ads.mediation:ironsource:3.4.+" />
-    <androidPackage spec="com.yumimobi.ads.mediation:mintegral:3.4.+" />
+    <androidPackage spec="com.yumimobi.ads:mediation:3.4.1" />
+    <androidPackage spec="com.yumimobi.ads.mediation:applovin:3.4.1" />
+    <androidPackage spec="com.yumimobi.ads.mediation:playableads:3.4.1" />
+    <androidPackage spec="com.yumimobi.ads.mediation:admob:3.4.1" />
+    <androidPackage spec="com.yumimobi.ads.mediation:chartboost:3.4.1" />
+    <androidPackage spec="com.yumimobi.ads.mediation:facebook:3.4.1" />
+    <androidPackage spec="com.yumimobi.ads.mediation:vungle:3.4.1" />
+    <androidPackage spec="com.yumimobi.ads.mediation:ironsource:3.4.1" />
+    <androidPackage spec="com.yumimobi.ads.mediation:mintegral:3.4.1" />
 
     <!--  If your app is only available in mainland China, use unity-china,else use Unity.   -->
-    <androidPackage spec="com.yumimobi.ads.mediation:unity:3.4.+" />
-    <!-- <androidPackage spec="com.yumimobi.ads.mediation:unity-china:3.4.+" /> -->
+    <androidPackage spec="com.yumimobi.ads.mediation:unity:3.4.1" />
+    <!-- <androidPackage spec="com.yumimobi.ads.mediation:unity-china:3.4.1" /> -->
 
     <repositories>
         <repository>https://jcenter.bintray.com/</repository>


### PR DESCRIPTION
The third part SDK named Mraid is a developing SDK, and it contants some sensitive permissions, like READ_PHONE_STATE. So if you  remove the SDK like the pr does, the sensitive permissions will disappear.

we update our Android mediation SDK and its adapters，attached the third SDK error information into the mediation callback. So you can know the detail description of the error.